### PR TITLE
Update conda install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ dependency automatically. First, make sure [bioconda] is set up properly with:
 ```
 Second, install or update your DrTransformer installation.
 ```sh
-  ~$ conda install drtransformer
+  ~$ conda install -c bioconda drtransformer
 ```
 
 ### Testing/Contributing


### PR DESCRIPTION
DrTransformer (at the time of writing) only appears to be available via the bioconda channel and will therefore fail to install unless  `-c bioconda` is specified in your `conda install` command. I just made a quick edit to add that to the README page